### PR TITLE
Issue 32: Support list and tuple argnames for @pytest.mark.parametrize.

### DIFF
--- a/pytest_describe/plugin.py
+++ b/pytest_describe/plugin.py
@@ -70,7 +70,10 @@ def merge_pytestmark(obj, parentobj):
 def pytestmark_name(mark):
     name = mark.name
     if name == 'parametrize':
-        name += '-' + mark.args[0]
+        argnames = mark.args[0]
+        if not isinstance(argnames, str):
+            argnames = ','.join(argnames)
+        name += '-' + argnames
     return name
 
 

--- a/test/test_marks.py
+++ b/test/test_marks.py
@@ -31,6 +31,33 @@ def test_special_marks(testdir):
     assert_outcomes(result, passed=3, xfailed=1, xpassed=1, skipped=1)
 
 
+
+def test_multiple_variables_parametrize(testdir):
+    a_dir = testdir.mkpydir('a_dir')
+    a_dir.join('test_a.py').write(py.code.Source("""
+        import pytest
+
+        def describe_marks():
+            @pytest.mark.parametrize('foo,bar', [(1, 2), (3, 4)])
+            def isint_str_names(foo, bar):
+                assert foo == int(foo)
+                assert bar == int(bar)
+
+            @pytest.mark.parametrize(['foo', 'bar'], [(1, 2), (3, 4)])
+            def isint_list_names(foo, bar):
+                assert foo == int(foo)
+                assert bar == int(bar)
+
+            @pytest.mark.parametrize(('foo', 'bar'), [(1, 2), (3, 4)])
+            def isint_tuple_names(foo, bar):
+                assert foo == int(foo)
+                assert bar == int(bar)
+    """))
+
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=6)
+
+
 def test_cartesian_parametrize(testdir):
     a_dir = testdir.mkpydir('a_dir')
     a_dir.join('test_a.py').write(py.code.Source("""


### PR DESCRIPTION
This commit affects the `pytestmark_name` method, which previously assumed that `mark.args[0]` was
always a str when converting the mark to a string.  However, `@pytest.mark.parametrize` permits an
`argnames` object which is a tuple or a list, for cases when you are parametrizing over multiple
variables.  This usage is now supported, and unit tests have been added.