### PR TITLE
Make markers consistent with pytest's defaults

### DIFF
--- a/test/util.py
+++ b/test/util.py
@@ -1,7 +1,7 @@
 def assert_outcomes(result, **expected):
     outcomes = result.parseoutcomes()
 
-    for key in 'seconds', 'warnings':
+    for key in 'seconds', 'warnings', 'warning':
         if key in outcomes:
             del outcomes[key]
 


### PR DESCRIPTION
* Make the markers defined on a describe block consistent with pytest's handling of marker propagation, by adding them to the describe block itself rather than each generated test case.
* Add two new test cases with advanced marker usage.
* Fix assertion helper when only one warning is produced on pytest 5.3.

This fixes an issue where markers could not be stacked properly in a describe block, see #36. The test case from that issue is included as a new test here.
Additionally, this makes it possible to have two separate `@behaves_like` blocks to define different marks and parametrizations. See the new `test_parametrize_with_shared_but_different_values` test case, which would fail before these changes. Although I have little experience with shared behaviours, it seems like a reasonable situation to allow.
Finally, this *significantly* simplifies the processing of markers, while still passing all tests.

Closes #36 