### PR TITLE
Proof of concept of fixtures as describe block funcargs

### DIFF
--- a/pytest_describe/plugin.py
+++ b/pytest_describe/plugin.py
@@ -1,10 +1,125 @@
+import contextlib
+import dis
+import functools
+import inspect
 import sys
 import types
+from collections import namedtuple
 from _pytest.python import PyCollector
+
+import pprint
+
+# Dummy objects that are passed as arguments to the describe blocks and are
+# later used to determine which fixture to inject into the test function's
+# closure.
+InjectFixture = namedtuple('_InjectFixture', ['name'])
+
+
+def accesses_arguments(funcobj):
+    """Inspect a function's bytecode to determine if it uses its parameters.
+
+    Used to determine whether the describe block itself may attempt to use the
+    dummy arguments we pass to it. Note that this may produce false positives.
+    """
+    # LOAD_DEREF is used to access free variables from a closure, so parameters
+    # from an outer function. LOAD_FAST is used to load parameters of the
+    # function itself.
+    parent_params = {
+        arg.name for arg in getattr(funcobj, '_parent_fixture_args', set())}
+    params = set(inspect.signature(funcobj).parameters) | parent_params
+
+    return any(
+        instr.opname in ('LOAD_DEREF', 'LOAD_FAST') and instr.argval in params
+        for instr in dis.get_instructions(funcobj))
+
+
+def raise_if_cannot_change_closure():
+    """Raise if we cannot change the closure in this Python version."""
+    def outer(x):
+        def inner():
+            return x
+        return inner
+    inner = outer(1)
+    try:
+        inner.__closure__[0].cel_contents = 2
+    except err:  # Not sure which exception it could be
+        raise PyCollector.CollectError(
+            'Passing fixture names to describe blocks is not supported in this'
+            'Python version') from err
+
+    if inner() != 2:
+        raise PyCollector.CollectError(
+            'Passing fixture names to describe blocks is not supported in this'
+            'Python version')
+
+
+def construct_injected_fixture_args(funcobj):
+    """Construct a set of dummy arguments that mark fixture injections."""
+    # TODO: How do we handle kw-only args, args with defaults?
+    return set(map(InjectFixture, inspect.signature(funcobj).parameters))
+
+
+def inject_fixtures(func, fixture_args):
+    if not isinstance(func, types.FunctionType):
+        return func
+
+    if hasattr(func, '_pytestfixturefunction'):
+        # TODO: How should we handle fixtures?
+        return func
+
+    if func.__name__.startswith('describe_'):
+        # FIXME: Allow customisation of describe prefix
+        return func
+
+    # Store all fixture args in all local functions. This is necessary for
+    # nested describe blocks.
+    func._parent_fixture_args = fixture_args
+
+    @contextlib.contextmanager
+    def _temp_change_cell(cell, new_value):
+        old_value = cell.cell_contents
+        cell.cell_contents = new_value
+        yield
+        cell.cell_contents = old_value
+
+    # Wrap the function in an extended function that takes the fixtures
+    # and updates the closure
+    def wrapped(request, **kwargs):
+        # Use the request fixture to get fixture values, and either feed those
+        # as parameters or inject them into the closure
+        with contextlib.ExitStack() as exit_stack:
+            for cell in (func.__closure__ or []):
+                if not isinstance(cell.cell_contents, InjectFixture):
+                    continue
+                fixt_value = request.getfixturevalue(cell.cell_contents.name)
+                exit_stack.enter_context(_temp_change_cell(cell, fixt_value))
+
+            direct_params = {}
+            for param in inspect.signature(func).parameters:
+                if param in kwargs:
+                    direct_params[param] = kwargs[param]
+                else:
+                    direct_params[param] = request.getfixturevalue(param)
+
+            func(**direct_params)
+
+    if hasattr(func, 'pytestmark'):
+        wrapped.pytestmark = func.pytestmark
+
+    return wrapped
 
 
 def trace_function(funcobj, *args, **kwargs):
-    """Call a function, and return its locals"""
+    """Call a function, and return its locals, wrapped to inject fixtures"""
+    if accesses_arguments(funcobj):
+        # Since describe blocks run during test collection rather than
+        # execution, fixture results aren't available. Although dereferencing
+        # our dummy objects will not directly lead to an error, it would surely
+        # lead to unexpected results.
+        raise PyCollector.CollectError(
+            'Describe blocks must not directly dereference their fixture '
+            'arguments')
+
     funclocals = {}
 
     def _tracefunc(frame, event, arg):
@@ -13,13 +128,19 @@ def trace_function(funcobj, *args, **kwargs):
             if event == 'return':
                 funclocals.update(frame.f_locals)
 
+    direct_fixture_args = construct_injected_fixture_args(funcobj)
+    parent_fixture_args = getattr(funcobj, '_parent_fixture_args', set())
+
     sys.setprofile(_tracefunc)
     try:
-        funcobj(*args, **kwargs)
+        # TODO: Are *args and **kwargs necessary here?
+        funcobj(*direct_fixture_args, *args, **kwargs)
     finally:
         sys.setprofile(None)
 
-    return funclocals
+    return {
+        name: inject_fixtures(obj, direct_fixture_args | parent_fixture_args)
+        for name, obj in funclocals.items()}
 
 
 def make_module_from_function(funcobj):
@@ -40,6 +161,7 @@ def make_module_from_function(funcobj):
 def evaluate_shared_behavior(funcobj):
     if not hasattr(funcobj, '_shared_functions'):
         funcobj._shared_functions = {}
+        # TODO: What to do with fixtures in shared behavior closures?
         for name, obj in trace_function(funcobj).items():
             # Only functions are relevant here
             if not isinstance(obj, types.FunctionType):

--- a/test/test_fixture_injection.py
+++ b/test/test_fixture_injection.py
@@ -1,0 +1,68 @@
+import py
+from util import assert_outcomes
+
+from pytest_describe.plugin import InjectFixture, accesses_arguments
+
+
+def test_accesses_arguments_params():
+    def f(x):
+        x
+
+    assert accesses_arguments(f)
+
+
+def test_accesses_arguments_closure():
+    def outer(x):
+        def inner():
+            x
+        return inner
+    inner = outer(1)
+    inner._parent_fixture_args = {InjectFixture('x')}
+
+    assert not accesses_arguments(outer)
+    assert accesses_arguments(inner)
+
+
+def test_accesses_arguments_locals():
+    def outer():
+        x = 1
+        x
+        print(x)
+
+    assert not accesses_arguments(outer)
+
+
+def test_accesses_arguments_outer_locals():
+    def outer():
+        x = 1
+        x
+        def inner():
+            x
+        return inner
+
+    assert not accesses_arguments(outer)
+    assert not accesses_arguments(outer())
+
+
+def test_inject_fixtures(testdir):
+    a_dir = testdir.mkpydir('a_dir')
+    a_dir.join('test_a.py').write(py.code.Source("""
+        import pytest
+
+        @pytest.fixture
+        def thing():
+            return 42
+
+        def describe_something(thing):
+
+            def thing_is_not_43():
+                assert thing != 43
+
+            def describe_nested_block():
+
+                def thing_is_42():
+                    assert thing == 42
+    """))
+
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=2)


### PR DESCRIPTION
I mentioned in #38 that I'd send a WIP PR if I managed to find some time, but of course I forgot. I had some time to do some hacking this evening, and I eventually arrived at a version that sort of achieves what I had hoped, so here it is. It's far from complete, there are numerous test failures and TODOs, in fact, but it's a start.

To summarise, what I did is capture the describe block's arguments using `inspect` and calling it with dummy arguments which store the argument name to gather the local definitions. When those dummy arguments are used in a test spec, they're added to the spec's closure, but we need the name as that would be the only way to match fixture values to the closure cells. Then I wrap each spec inside of a new function which loads the fixture values and either passes them as a normal argument, or temporarily modifies the closure to inject it. I've also added a sort of defence mechanism to prevent dereferencing the dummy arguments in the describe block itself, as that would lead to unexpected behaviour. This is done by scanning the function's bytecode for certain opcodes that load those arguments, but it's not thoroughly tested yet and likely not 100% reliable.

The main TODOs:
- [ ] If fixtures can be injected into specs, should they also be injected into other fixtures nested in the describe block (if necessary)? Currently, they're just skipped.
- [ ] More importantly, this completely breaks with `@pytest.mark.parametrize`, as that scans the test spec's params to check if it actually uses the parametrized variable. However, we're returning the wrapper, which doesn't include those params, so that fails. This could be fixed with some more meta-hacking or hooking more into pytest itself. [hypothesis faced a similar problem and solved it by dynamically defining a new function with the adapted signature using `exec`](https://github.com/HypothesisWorks/hypothesis/blob/bf2c4be6f86ccb88a496373b24e92ad8e270bc01/hypothesis-python/src/hypothesis/internal/reflection.py#L458).
- [ ] Significantly more testing is required.
- [ ] How this interacts with shared behaviours remains to be seen. I don't think it would make much sense to allow arguments on shared behaviour blocks, as that would require somehow injecting those arguments into the local scope of the `@behaves_like` describe block. I don't want to rule out that possibility, but that could easily get very messy very quickly.

Smaller TODOs:
- [ ] This might break with kw-only arguments or arguments with default values. I'm not sure whether they'd make sense in this context, though.
- [ ] It only supports the default describe prefix for now, as I didn't bother passing around config yet.
- [ ] There's a function that checks whether the closure hacking is actually possible in the given Python version, but I'm not using it yet. It should be used to raise an error at collection time already.
- [ ] Perhaps an easier way to do this would be to rewrite the AST, but that's still very complex and I'm concerned about the effect on coverage tools.

All in all, I'm of the opinion that this is all some very cool and interesting meta-hacking, but I'm concerned as to whether it's worthwhile continuing this endeavour. This buggy implementation already doubled the size of the plugin's main code, and I'm expecting it to grow significantly more to account for some of the TODOs. All that to prevent an error which is trivial to fix, and becomes a non-issue very quickly. It's certainly flashy and a cool example of dependency injection, but I'm not sure that the substantial increase in complexity and future maintenance efforts would be worth it.

Unless there's high demand for this or I'm craving another meta-hacking session, it's unlikely that I'll continue work on this any time soon. So if anyone wants to work further on this (or start from scratch), feel free to do so.