### PR TITLE
✨ allow pytest_asyncio compatibility

### DIFF
--- a/pytest_describe/plugin.py
+++ b/pytest_describe/plugin.py
@@ -1,5 +1,7 @@
 """The pytest-describe plugin"""
 
+import asyncio
+import inspect
 import sys
 import types
 import pytest
@@ -21,7 +23,7 @@ def trace_function(func, *args, **kwargs):  # pragma: no-cover
 
     sys.setprofile(_trace_func)
     try:
-        func(*args, **kwargs)
+        asyncio.run(func(*args, **kwargs)) if inspect.iscoroutinefunction(func) else func(*args, **kwargs)
     finally:
         sys.setprofile(None)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,3 @@
 """Global fixtures for testing the plugin"""
 
-pytest_plugins = ["pytester"]
+pytest_plugins = ["pytester", "pytest_asyncio"]

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -45,3 +45,22 @@ def test_can_fail_and_pass(testdir):
 
     result = testdir.runpytest()
     result.assert_outcomes(passed=1, failed=1)
+
+
+def test_can_run_async_tests(testdir):
+    testdir.makepyfile(
+        """
+        import asyncio
+        import pytest
+
+        @pytest.mark.asyncio
+        async def describe_something():
+            async def describe_nested_ok():
+                async def passes():
+                    assert True
+            async def describe_nested_bad():
+                async def fails():
+                    assert False
+        """)
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1, failed=1)


### PR DESCRIPTION
Simple PR to add compatibility with `pytest_asyncio` (but generally speaking async tests).

I had an issue in a FastAPI project with Async routes where I wanted to test (and I use this because I like the '[jasmine](https://jasmine.github.io/)'-style of writing unit tests.



