### PR TITLE
Make describe functions available to reporting

### DIFF
--- a/src/pytest_describe/plugin.py
+++ b/src/pytest_describe/plugin.py
@@ -99,6 +99,21 @@ class DescribeBlock(pytest.Module):
         self.name = name
         self.funcobj = obj
         return self
+    
+    @property
+    def describe_function_heirarchy(self):
+        """Get the hierarchy of describe functions leading to and including this block"""
+        if not hasattr(self, "_describe_function_heirarchy"):
+            hierarchy = []
+            current = self
+            
+            while current:
+                if isinstance(current, DescribeBlock):
+                    hierarchy.append(current.funcobj)
+                current = current.parent
+
+            self._describe_function_heirarchy = hierarchy
+        return self._describe_function_heirarchy
 
     def collect(self):
         """Get list of children"""
@@ -136,7 +151,19 @@ def pytest_pycollect_makeitem(collector, name, obj):
         for prefix in collector.config.getini("describe_prefixes"):
             if obj.__name__.startswith(prefix):
                 return DescribeBlock.from_parent(collector, obj)
+            
+def pytest_collection_modifyitems(session, config, items):
+    """Add API to all test items to get the describe heirarchy."""
+    for item in items:
+        item.get_describe_function_heirarchy = types.MethodType(get_describe_function_heirarchy, item)
 
+def get_describe_function_heirarchy(self):
+    """Get the hierarchy of describe functions leading to this test item"""
+    return (
+        self.parent.describe_function_heirarchy
+        if hasattr(self, "parent") and hasattr(self.parent, "describe_function_heirarchy")
+        else []
+    )
 
 def pytest_addoption(parser):
     """Add configuration option describe_prefixes."""


### PR DESCRIPTION
## What's changing
This change exposes a new API on collected test items called `Item.get_describe_function_heirarchy()`. This function allows reporter plugins to gain access to the describe functions that were used to define the test suite structure.

## API changes
### Item.get_describe_function_heirarchy()
- Returns a list of all the ancestor describe functions that wrap around the test item.
  - The list is ordered starting with the describe that is closest to the test item.
- Delegates to the property `DescribeBlock.describe_function_heirarchy` to get the list.

### DescribeBlock.describe_function_heirarchy
- Computes the hierarchy from this describe up to the top most describe. Includes this describe in the list.
- Memoizes the result so it doesn't need to be computed for every test item.
- Does not compute the list until it is requested, so there is no wasted effort if the new API is not used.

## Planed integration
I have implemented a change in [pytest-spec](https://github.com/pchomik/pytest-spec/compare/master...joshuaprior:pytest-spec:add-container-formatting?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to use this new API to provide docstring support for formatting describe statements.

<img width="519" height="322" alt="image" src="https://github.com/user-attachments/assets/0bd4d779-f44b-4d91-a1cf-57d79da771a1" />
